### PR TITLE
Support shadow state report on disconnection by LWT

### DIFF
--- a/device/app.py
+++ b/device/app.py
@@ -86,6 +86,8 @@ def make_shadow():
     s.configureAutoReconnectBackoffTime(1, 32, 20)
     s.configureConnectDisconnectTimeout(10)  # 10 sec
     s.configureMQTTOperationTimeout(5)  # 5 sec
+    print('Configuring last will message with the following payload ...')
+    s.configureLastWill("my/things/{}/update".format(a.thingName), ShadowPayload.encode(0, 0, 0, 0), 0)
     s.connect()
     return s.createShadowHandlerWithName(a.thingName, True)
 


### PR DESCRIPTION
Last will message is configured so that shadow state is reported
on device disconnection from AWS IoT.

To publish LWT to the device shadow topic, AWS IoT rule to republish
from the bridging topic to it need to be configured.